### PR TITLE
Rotation as part of initial parameters

### DIFF
--- a/carla_sim/parameters/spawn.yaml
+++ b/carla_sim/parameters/spawn.yaml
@@ -1,6 +1,7 @@
 ev:
   start: [30.874001, 7.542412, 0.3]
   end: [205.874001, 8.542412, 0.3]
+  rotation: [0.0, 0.0, 0.0]
 
 npc1:
   start: [40.874001, 3.542412, 0.3]
@@ -8,6 +9,7 @@ npc1:
   brake_chance: 0.3
   brake_range: [0.0, 0.5]
   steer_range: [0.0, 0.02]
+  rotation: [0.0, 0.0, 0.0]
 
 npc2:
   start: [70.874001, 7.542412, 0.3]
@@ -15,6 +17,7 @@ npc2:
   brake_chance: 0.3
   brake_range: [0.0, 0.4]
   steer_range: [0.0, 0.02]
+  rotation: [0.0, 0.0, 0.0]
 
 pedestrian1:
   start: [65.874001, 3.542412, 0.3]

--- a/carla_sim/simulation.py
+++ b/carla_sim/simulation.py
@@ -45,24 +45,24 @@ def run_simulation(spawn_config, weather_params,
 
     blueprint_library = world.get_blueprint_library()
     vehicle_bp = blueprint_library.filter('vehicle.tesla.model3')[0]
-    ev_tf   = tools.list_to_transform(spawn_config['ev']['start'])
-    ev_end  = tools.list_to_transform(spawn_config['ev']['end']).location
+    ev_tf   = tools.lists_to_transform(spawn_config['ev']['start'], spawn_config['ev']['rotation'])
+    ev_end  = tools.lists_to_transform(spawn_config['ev']['end']).location
 
     vehicle = world.spawn_actor(vehicle_bp, ev_tf)
     agent = BehaviorAgent(vehicle, behavior='normal')
     agent.set_destination(ev_end)
 
 
-    npc1 = tools.spawn_npc(world, blueprint_library, tools.list_to_transform(spawn_config['npc1']['start']))
-    npc2 = tools.spawn_npc(world, blueprint_library, tools.list_to_transform(spawn_config['npc2']['start']))
+    npc1 = tools.spawn_npc(world, blueprint_library, tools.lists_to_transform(spawn_config['npc1']['start'], spawn_config['npc1']['rotation']))
+    npc2 = tools.spawn_npc(world, blueprint_library, tools.lists_to_transform(spawn_config['npc2']['start'], spawn_config['npc2']['rotation']))
 
     walker1_bp = blueprint_library.find('walker.pedestrian.0001')
     walker2_bp = blueprint_library.find('walker.pedestrian.0002')
 
-    ped1_start = tools.list_to_transform(spawn_config['pedestrian1']['start'])
+    ped1_start = tools.lists_to_transform(spawn_config['pedestrian1']['start'])
     ped1_end = tools.list_to_location(spawn_config['pedestrian1']['end'])
 
-    ped2_start = tools.list_to_transform(spawn_config['pedestrian2']['start'])
+    ped2_start = tools.lists_to_transform(spawn_config['pedestrian2']['start'])
     ped2_end = tools.list_to_location(spawn_config['pedestrian2']['end'])
 
     walker1 = world.spawn_actor(walker1_bp, ped1_start)

--- a/carla_sim/tools.py
+++ b/carla_sim/tools.py
@@ -37,9 +37,10 @@ def load_weather_yaml(path):
         return yaml.safe_load(f)
 def list_to_location(lst):
     return carla.Location(x=lst[0], y=lst[1], z=lst[2])
-
-def list_to_transform(lst):
-    return carla.Transform(list_to_location(lst), carla.Rotation())
+def list_to_rotation(lst):
+    return carla.Rotation(x=lst[0], y=lst[1], z=lst[2])
+def lists_to_transform(lst, lst2=[0,0,0]):
+    return carla.Transform(list_to_location(lst), list_to_rotation(lst2))
 
 def load_ga_config(path):
     if not os.path.exists(path):


### PR DESCRIPTION
This pull request would enable test scenarios to include initial rotation as part of their parameters, enabling vehicles to be properly spawned on lanes that do not move in the positive x-direction. Slightly modifies function signatures in tools in order to do this.